### PR TITLE
feat(cli): enhance mode defaults and streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ providers:
 
 See `examples/config.yml` and `examples/config.json` for complete examples.
 
+Configuration files support shell-style environment variable references like ${OPENAI_API_KEY}, which are expanded at load time.
+
 ### Environment Variables
 
 Set up your API keys and configuration:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,7 +82,7 @@ func NewConfig() *Config {
 // loadConfigFile attempts to load configuration from file
 func loadConfigFile() (*FileConfig, error) {
 	configDir := getConfigDir()
-	
+
 	// Try YAML first, then JSON
 	for _, ext := range []string{"yml", "yaml", "json"} {
 		configPath := filepath.Join(configDir, "gpt-cli", "config."+ext)
@@ -90,7 +90,7 @@ func loadConfigFile() (*FileConfig, error) {
 			return config, nil
 		}
 	}
-	
+
 	return nil, fmt.Errorf("no config file found")
 }
 
@@ -102,7 +102,7 @@ func loadConfigFromPath(path string) (*FileConfig, error) {
 	}
 
 	var config FileConfig
-	
+
 	// Determine format by extension
 	ext := filepath.Ext(path)
 	switch ext {
@@ -113,12 +113,26 @@ func loadConfigFromPath(path string) (*FileConfig, error) {
 	default:
 		return nil, fmt.Errorf("unsupported config file format: %s", ext)
 	}
-	
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config file %s: %w", path, err)
 	}
-	
+
+	expandEnvFileConfig(&config)
 	return &config, nil
+}
+
+// expandEnvFileConfig replaces ${VAR} style expressions with env values
+func expandEnvFileConfig(cfg *FileConfig) {
+	cfg.Provider = os.ExpandEnv(cfg.Provider)
+	cfg.Model = os.ExpandEnv(cfg.Model)
+	cfg.System = os.ExpandEnv(cfg.System)
+	cfg.Providers.OpenAI.APIKey = os.ExpandEnv(cfg.Providers.OpenAI.APIKey)
+	cfg.Providers.OpenAI.BaseURL = os.ExpandEnv(cfg.Providers.OpenAI.BaseURL)
+	cfg.Providers.Copilot.APIKey = os.ExpandEnv(cfg.Providers.Copilot.APIKey)
+	cfg.Providers.Copilot.BaseURL = os.ExpandEnv(cfg.Providers.Copilot.BaseURL)
+	cfg.Providers.Gemini.APIKey = os.ExpandEnv(cfg.Providers.Gemini.APIKey)
+	cfg.Providers.Gemini.BaseURL = os.ExpandEnv(cfg.Providers.Gemini.BaseURL)
 }
 
 // mergeFileConfig merges file configuration into the main config

--- a/internal/modes/chat.go
+++ b/internal/modes/chat.go
@@ -5,17 +5,17 @@ import (
 	"strings"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/anschmieg/gpt-cli/internal/config"
 	"github.com/anschmieg/gpt-cli/internal/providers"
 	"github.com/anschmieg/gpt-cli/internal/ui"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // Message represents a single message in the conversation
 type Message struct {
-	Role      string    `json:"role"`      // "user", "assistant", "system"
-	Content   string    `json:"content"`   
+	Role      string    `json:"role"` // "user", "assistant", "system"
+	Content   string    `json:"content"`
 	Timestamp time.Time `json:"timestamp"`
 }
 
@@ -37,15 +37,16 @@ type ChatMode struct {
 
 // ChatModel represents the BubbleTea model for chat mode
 type ChatModel struct {
-	chatMode     *ChatMode
-	state        ChatState
-	input        string
-	cursor       int
-	width        int
-	height       int
-	loading      bool
-	error        string
-	scrollOffset int
+	chatMode      *ChatMode
+	state         ChatState
+	input         string
+	cursor        int
+	width         int
+	height        int
+	loading       bool
+	error         string
+	scrollOffset  int
+	initialPrompt string
 }
 
 // ChatState represents the current state of the chat
@@ -85,16 +86,31 @@ func NewChatMode(config *config.Config, provider providers.Provider, ui *ui.UI) 
 }
 
 // NewChatModel creates a new BubbleTea model for chat mode
-func NewChatModel(chatMode *ChatMode) *ChatModel {
+func NewChatModel(chatMode *ChatMode, initial string) *ChatModel {
 	return &ChatModel{
-		chatMode: chatMode,
-		state:    ChatStateInput,
+		chatMode:      chatMode,
+		state:         ChatStateInput,
+		initialPrompt: initial,
 	}
 }
 
 // Init initializes the chat model
 func (m *ChatModel) Init() tea.Cmd {
-	return tea.EnterAltScreen
+	cmds := []tea.Cmd{tea.EnterAltScreen}
+	if strings.TrimSpace(m.initialPrompt) != "" {
+		m.state = ChatStateLoading
+		m.loading = true
+		prompt := strings.TrimSpace(m.initialPrompt)
+		m.initialPrompt = ""
+		m.chatMode.conversation.Messages = append(m.chatMode.conversation.Messages, Message{
+			Role:      "user",
+			Content:   prompt,
+			Timestamp: time.Now(),
+		})
+		m.chatMode.conversation.Updated = time.Now()
+		cmds = append(cmds, m.makeRequest())
+	}
+	return tea.Batch(cmds...)
 }
 
 // Update handles messages and updates the chat model
@@ -111,7 +127,7 @@ func (m *ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ResponseMsg:
 		m.state = ChatStateResponse
 		m.loading = false
-		
+
 		// Add assistant message to conversation
 		m.chatMode.conversation.Messages = append(m.chatMode.conversation.Messages, Message{
 			Role:      "assistant",
@@ -119,7 +135,7 @@ func (m *ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Timestamp: time.Now(),
 		})
 		m.chatMode.conversation.Updated = time.Now()
-		
+
 		return m, nil
 
 	case ErrorMsg:
@@ -227,7 +243,7 @@ func (m *ChatModel) sendMessage() (tea.Model, tea.Cmd) {
 // clearConversation clears the conversation history
 func (m *ChatModel) clearConversation() (tea.Model, tea.Cmd) {
 	m.chatMode.conversation.Messages = []Message{}
-	
+
 	// Re-add system message if configured
 	if m.chatMode.config.System != "" {
 		m.chatMode.conversation.Messages = append(m.chatMode.conversation.Messages, Message{
@@ -236,12 +252,12 @@ func (m *ChatModel) clearConversation() (tea.Model, tea.Cmd) {
 			Timestamp: time.Now(),
 		})
 	}
-	
+
 	m.chatMode.conversation.Updated = time.Now()
 	m.state = ChatStateInput
 	m.error = ""
 	m.scrollOffset = 0
-	
+
 	return m, nil
 }
 
@@ -250,7 +266,7 @@ func (m *ChatModel) makeRequest() tea.Cmd {
 	return func() tea.Msg {
 		// Convert conversation messages to the format expected by the provider
 		prompt := m.formatConversationForProvider()
-		
+
 		response, err := m.chatMode.provider.CallProvider(prompt)
 		if err != nil {
 			return ErrorMsg{Error: err.Error()}
@@ -262,7 +278,7 @@ func (m *ChatModel) makeRequest() tea.Cmd {
 // formatConversationForProvider formats the conversation for the provider
 func (m *ChatModel) formatConversationForProvider() string {
 	var parts []string
-	
+
 	for _, msg := range m.chatMode.conversation.Messages {
 		switch msg.Role {
 		case "system":
@@ -275,7 +291,7 @@ func (m *ChatModel) formatConversationForProvider() string {
 			parts = append(parts, fmt.Sprintf("Assistant: %s", msg.Content))
 		}
 	}
-	
+
 	return strings.Join(parts, "\n\n")
 }
 
@@ -298,7 +314,7 @@ func (m *ChatModel) View() string {
 // renderChatView renders the main chat interface
 func (m *ChatModel) renderChatView() string {
 	title := m.chatMode.ui.TitleStyle.Render("💬 Chat Mode")
-	
+
 	// Conversation info
 	msgCount := len(m.chatMode.conversation.Messages)
 	userMsgCount := 0
@@ -307,7 +323,7 @@ func (m *ChatModel) renderChatView() string {
 			userMsgCount++
 		}
 	}
-	
+
 	info := m.chatMode.ui.SubtitleStyle.Render(fmt.Sprintf(
 		"Messages: %d | User: %d | Provider: %s | Model: %s",
 		msgCount,
@@ -318,7 +334,7 @@ func (m *ChatModel) renderChatView() string {
 
 	// Chat history
 	history := m.renderChatHistory()
-	
+
 	// Input area
 	var inputArea string
 	if m.loading {
@@ -328,7 +344,7 @@ func (m *ChatModel) renderChatView() string {
 		input := m.chatMode.ui.InputStyle.Render("> " + m.input + "█")
 		inputArea = lipgloss.JoinVertical(lipgloss.Left, prompt, input)
 	}
-	
+
 	// Help text
 	help := m.chatMode.ui.HelpStyle.Render("Enter: Send • Ctrl+L: Clear • Ctrl+C/q: Quit • ↑↓: Scroll • Esc: Input mode")
 
@@ -355,21 +371,21 @@ func (m *ChatModel) renderChatHistory() string {
 	}
 
 	var messages []string
-	
+
 	// Apply scroll offset
 	visibleMessages := m.chatMode.conversation.Messages
 	if m.scrollOffset > 0 && m.scrollOffset < len(visibleMessages) {
 		visibleMessages = visibleMessages[:len(visibleMessages)-m.scrollOffset]
 	}
-	
+
 	for _, msg := range visibleMessages {
 		if msg.Role == "system" {
 			continue // Don't show system messages in chat history
 		}
-		
+
 		var rendered string
 		timestamp := msg.Timestamp.Format("15:04")
-		
+
 		switch msg.Role {
 		case "user":
 			header := lipgloss.NewStyle().
@@ -378,13 +394,13 @@ func (m *ChatModel) renderChatHistory() string {
 				Render(fmt.Sprintf("You (%s):", timestamp))
 			content := msg.Content
 			rendered = fmt.Sprintf("%s\n%s", header, content)
-			
+
 		case "assistant":
 			header := lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#7C3AED")).
 				Bold(true).
 				Render(fmt.Sprintf("Assistant (%s):", timestamp))
-			
+
 			var content string
 			if m.chatMode.config.Markdown && m.chatMode.ui.IsMarkdown(msg.Content) {
 				content = m.chatMode.ui.RenderMarkdown(msg.Content)
@@ -393,18 +409,18 @@ func (m *ChatModel) renderChatHistory() string {
 			}
 			rendered = fmt.Sprintf("%s\n%s", header, content)
 		}
-		
+
 		if rendered != "" {
 			messages = append(messages, rendered)
 		}
 	}
-	
+
 	if len(messages) == 0 {
 		return m.chatMode.ui.SubtitleStyle.Render("No conversation history to display.")
 	}
-	
+
 	historyContent := strings.Join(messages, "\n\n")
-	
+
 	// Wrap in a scrollable container
 	return m.chatMode.ui.ResponseStyle.Render(historyContent)
 }
@@ -476,17 +492,17 @@ func (c *ChatMode) LoadConversation(conversation *Conversation) {
 // ExportConversation exports the conversation in a readable format
 func (c *ChatMode) ExportConversation() string {
 	var parts []string
-	
+
 	parts = append(parts, fmt.Sprintf("# Conversation %s", c.conversation.ID))
 	parts = append(parts, fmt.Sprintf("Created: %s", c.conversation.Created.Format("2006-01-02 15:04:05")))
 	parts = append(parts, fmt.Sprintf("Updated: %s", c.conversation.Updated.Format("2006-01-02 15:04:05")))
 	parts = append(parts, "")
-	
+
 	for _, msg := range c.conversation.Messages {
 		if msg.Role == "system" {
 			continue
 		}
-		
+
 		var role string
 		switch msg.Role {
 		case "user":
@@ -494,10 +510,10 @@ func (c *ChatMode) ExportConversation() string {
 		case "assistant":
 			role = "**Assistant**"
 		}
-		
+
 		timestamp := msg.Timestamp.Format("15:04")
 		parts = append(parts, fmt.Sprintf("%s (%s):\n%s\n", role, timestamp, msg.Content))
 	}
-	
+
 	return strings.Join(parts, "\n")
 }

--- a/internal/modes/chat_test.go
+++ b/internal/modes/chat_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/anschmieg/gpt-cli/internal/config"
 	"github.com/anschmieg/gpt-cli/internal/ui"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,15 +19,15 @@ func TestNewChatMode(t *testing.T) {
 	}
 	provider := &MockProvider{}
 	ui := ui.New()
-	
+
 	mode := NewChatMode(cfg, provider, ui)
-	
+
 	assert.NotNil(t, mode)
 	assert.Equal(t, cfg, mode.config)
 	assert.Equal(t, provider, mode.provider)
 	assert.Equal(t, ui, mode.ui)
 	assert.NotNil(t, mode.conversation)
-	
+
 	// Should have system message
 	require.Len(t, mode.conversation.Messages, 1)
 	assert.Equal(t, "system", mode.conversation.Messages[0].Role)
@@ -38,10 +38,10 @@ func TestNewChatModel(t *testing.T) {
 	cfg := &config.Config{Provider: "mock", Model: "test-model"}
 	provider := &MockProvider{}
 	ui := ui.New()
-	
+
 	chatMode := NewChatMode(cfg, provider, ui)
-	model := NewChatModel(chatMode)
-	
+	model := NewChatModel(chatMode, "")
+
 	assert.NotNil(t, model)
 	assert.Equal(t, chatMode, model.chatMode)
 	assert.Equal(t, ChatStateInput, model.state)
@@ -54,32 +54,50 @@ func TestChatModelInit(t *testing.T) {
 	cfg := &config.Config{Provider: "mock", Model: "test-model"}
 	provider := &MockProvider{}
 	ui := ui.New()
-	
+
 	chatMode := NewChatMode(cfg, provider, ui)
-	model := NewChatModel(chatMode)
-	
+	model := NewChatModel(chatMode, "")
+
 	cmd := model.Init()
 	assert.NotNil(t, cmd) // Just check that a command is returned
+}
+
+func TestChatModelInitWithInitialPrompt(t *testing.T) {
+	cfg := &config.Config{Provider: "mock", Model: "test-model"}
+	provider := &MockProvider{response: "Hello!"}
+	ui := ui.New()
+
+	chatMode := NewChatMode(cfg, provider, ui)
+	model := NewChatModel(chatMode, "Hi")
+
+	cmd := model.Init()
+	require.NotNil(t, cmd)
+
+	// Should have user message added
+	require.Len(t, chatMode.conversation.Messages, 1)
+	assert.Equal(t, "user", chatMode.conversation.Messages[0].Role)
+	assert.Equal(t, ChatStateLoading, model.state)
+	assert.True(t, model.loading)
 }
 
 func TestChatModelUpdate(t *testing.T) {
 	cfg := &config.Config{Provider: "mock", Model: "test-model"}
 	provider := &MockProvider{}
 	ui := ui.New()
-	
+
 	chatMode := NewChatMode(cfg, provider, ui)
-	model := NewChatModel(chatMode)
-	
+	model := NewChatModel(chatMode, "")
+
 	t.Run("window size message", func(t *testing.T) {
 		msg := tea.WindowSizeMsg{Width: 80, Height: 24}
 		updatedModel, cmd := model.Update(msg)
-		
+
 		assert.Nil(t, cmd)
 		chatModel := updatedModel.(*ChatModel)
 		assert.Equal(t, 80, chatModel.width)
 		assert.Equal(t, 24, chatModel.height)
 	})
-	
+
 	t.Run("response message", func(t *testing.T) {
 		// First add a user message
 		model.chatMode.conversation.Messages = append(model.chatMode.conversation.Messages, Message{
@@ -87,33 +105,33 @@ func TestChatModelUpdate(t *testing.T) {
 			Content:   "Hello",
 			Timestamp: time.Now(),
 		})
-		
+
 		msg := ResponseMsg{Content: "Hello! How can I help you?"}
 		updatedModel, cmd := model.Update(msg)
-		
+
 		assert.Nil(t, cmd)
 		chatModel := updatedModel.(*ChatModel)
 		assert.Equal(t, ChatStateResponse, chatModel.state)
 		assert.False(t, chatModel.loading)
-		
+
 		// Should have added assistant message
 		messages := chatModel.chatMode.conversation.Messages
 		require.Len(t, messages, 2) // user + assistant
 		assert.Equal(t, "assistant", messages[1].Role)
 		assert.Equal(t, "Hello! How can I help you?", messages[1].Content)
 	})
-	
+
 	t.Run("error message", func(t *testing.T) {
 		msg := ErrorMsg{Error: "Something went wrong"}
 		updatedModel, cmd := model.Update(msg)
-		
+
 		assert.Nil(t, cmd)
 		chatModel := updatedModel.(*ChatModel)
 		assert.Equal(t, ChatStateError, chatModel.state)
 		assert.Equal(t, "Something went wrong", chatModel.error)
 		assert.False(t, chatModel.loading)
 	})
-	
+
 	t.Run("stream chunk message", func(t *testing.T) {
 		// Add assistant message first
 		model.chatMode.conversation.Messages = append(model.chatMode.conversation.Messages, Message{
@@ -121,13 +139,13 @@ func TestChatModelUpdate(t *testing.T) {
 			Content:   "Hello",
 			Timestamp: time.Now(),
 		})
-		
+
 		msg := StreamChunkMsg{Chunk: " world!"}
 		updatedModel, cmd := model.Update(msg)
-		
+
 		assert.Nil(t, cmd)
 		chatModel := updatedModel.(*ChatModel)
-		
+
 		// Should have appended to last assistant message
 		messages := chatModel.chatMode.conversation.Messages
 		lastMsg := messages[len(messages)-1]
@@ -140,81 +158,81 @@ func TestChatModelKeyHandling(t *testing.T) {
 	cfg := &config.Config{Provider: "mock", Model: "test-model"}
 	provider := &MockProvider{response: "Test response"}
 	ui := ui.New()
-	
+
 	chatMode := NewChatMode(cfg, provider, ui)
-	model := NewChatModel(chatMode)
-	
+	model := NewChatModel(chatMode, "")
+
 	t.Run("typing input", func(t *testing.T) {
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")}
 		updatedModel, cmd := model.Update(msg)
-		
+
 		assert.Nil(t, cmd)
 		chatModel := updatedModel.(*ChatModel)
 		assert.Equal(t, "h", chatModel.input)
 	})
-	
+
 	t.Run("backspace", func(t *testing.T) {
 		model.input = "hello"
 		msg := tea.KeyMsg{Type: tea.KeyBackspace}
 		updatedModel, cmd := model.Update(msg)
-		
+
 		assert.Nil(t, cmd)
 		chatModel := updatedModel.(*ChatModel)
 		assert.Equal(t, "hell", chatModel.input)
 	})
-	
+
 	t.Run("enter with input", func(t *testing.T) {
 		model.input = "test message"
 		msg := tea.KeyMsg{Type: tea.KeyEnter}
 		updatedModel, cmd := model.Update(msg)
-		
+
 		assert.NotNil(t, cmd)
 		chatModel := updatedModel.(*ChatModel)
 		assert.Equal(t, ChatStateLoading, chatModel.state)
 		assert.True(t, chatModel.loading)
 		assert.Empty(t, chatModel.input) // Should be cleared
-		
+
 		// Should have added user message
 		messages := chatModel.chatMode.conversation.Messages
 		lastMsg := messages[len(messages)-1]
 		assert.Equal(t, "user", lastMsg.Role)
 		assert.Equal(t, "test message", lastMsg.Content)
 	})
-	
+
 	t.Run("clear conversation", func(t *testing.T) {
 		// Add some messages
-		model.chatMode.conversation.Messages = append(model.chatMode.conversation.Messages, 
+		model.chatMode.conversation.Messages = append(model.chatMode.conversation.Messages,
 			Message{Role: "user", Content: "Hello", Timestamp: time.Now()},
 			Message{Role: "assistant", Content: "Hi there!", Timestamp: time.Now()},
 		)
-		
+
 		msg := tea.KeyMsg{Type: tea.KeyCtrlL}
 		updatedModel, cmd := model.Update(msg)
-		
+
 		assert.Nil(t, cmd)
 		chatModel := updatedModel.(*ChatModel)
 		assert.Equal(t, ChatStateInput, chatModel.state)
 		assert.Empty(t, chatModel.error)
-		
+
 		// Should have cleared messages (except system message if present)
 		assert.Len(t, chatModel.chatMode.conversation.Messages, 0)
 	})
-	
+
 	t.Run("quit", func(t *testing.T) {
 		msg := tea.KeyMsg{Type: tea.KeyCtrlC}
 		updatedModel, cmd := model.Update(msg)
-		
+
 		assert.NotNil(t, cmd) // Should return a quit command
 		assert.NotNil(t, updatedModel)
 	})
-	
+
 	t.Run("escape from error state", func(t *testing.T) {
 		model.state = ChatStateError
 		model.error = "Some error"
-		
+
 		msg := tea.KeyMsg{Type: tea.KeyEsc}
 		updatedModel, cmd := model.Update(msg)
-		
+
 		assert.Nil(t, cmd)
 		chatModel := updatedModel.(*ChatModel)
 		assert.Equal(t, ChatStateInput, chatModel.state)
@@ -226,19 +244,19 @@ func TestFormatConversationForProvider(t *testing.T) {
 	cfg := &config.Config{Provider: "mock", Model: "test-model", System: "You are helpful"}
 	provider := &MockProvider{}
 	ui := ui.New()
-	
+
 	chatMode := NewChatMode(cfg, provider, ui)
-	model := NewChatModel(chatMode)
-	
+	model := NewChatModel(chatMode, "")
+
 	// Add some messages
 	model.chatMode.conversation.Messages = append(model.chatMode.conversation.Messages,
 		Message{Role: "user", Content: "Hello", Timestamp: time.Now()},
 		Message{Role: "assistant", Content: "Hi there!", Timestamp: time.Now()},
 		Message{Role: "user", Content: "How are you?", Timestamp: time.Now()},
 	)
-	
+
 	formatted := model.formatConversationForProvider()
-	
+
 	expected := "You are helpful\n\nUser: Hello\n\nAssistant: Hi there!\n\nUser: How are you?"
 	assert.Equal(t, expected, formatted)
 }
@@ -247,11 +265,11 @@ func TestGenerateConversationID(t *testing.T) {
 	id1 := generateConversationID()
 	time.Sleep(1 * time.Second) // Ensure different timestamp
 	id2 := generateConversationID()
-	
+
 	assert.NotEqual(t, id1, id2)
 	assert.Contains(t, id1, "chat_")
 	assert.Contains(t, id2, "chat_")
-	
+
 	// Test that they both follow expected format
 	assert.Regexp(t, `^chat_\d+$`, id1)
 	assert.Regexp(t, `^chat_\d+$`, id2)
@@ -261,15 +279,15 @@ func TestConversationMethods(t *testing.T) {
 	cfg := &config.Config{Provider: "mock", Model: "test-model"}
 	provider := &MockProvider{}
 	ui := ui.New()
-	
+
 	chatMode := NewChatMode(cfg, provider, ui)
-	
+
 	t.Run("GetConversation", func(t *testing.T) {
 		conv := chatMode.GetConversation()
 		assert.NotNil(t, conv)
 		assert.Equal(t, chatMode.conversation, conv)
 	})
-	
+
 	t.Run("LoadConversation", func(t *testing.T) {
 		newConv := &Conversation{
 			ID:       "test_conv",
@@ -277,20 +295,20 @@ func TestConversationMethods(t *testing.T) {
 			Created:  time.Now(),
 			Updated:  time.Now(),
 		}
-		
+
 		chatMode.LoadConversation(newConv)
 		assert.Equal(t, newConv, chatMode.conversation)
 	})
-	
+
 	t.Run("ExportConversation", func(t *testing.T) {
 		// Add some messages
 		chatMode.conversation.Messages = []Message{
 			{Role: "user", Content: "Hello", Timestamp: time.Now()},
 			{Role: "assistant", Content: "Hi there!", Timestamp: time.Now()},
 		}
-		
+
 		exported := chatMode.ExportConversation()
-		
+
 		assert.Contains(t, exported, "# Conversation")
 		assert.Contains(t, exported, "Created:")
 		assert.Contains(t, exported, "Updated:")
@@ -305,53 +323,53 @@ func TestChatModelView(t *testing.T) {
 	cfg := &config.Config{Provider: "mock", Model: "test-model"}
 	provider := &MockProvider{}
 	ui := ui.New()
-	
+
 	chatMode := NewChatMode(cfg, provider, ui)
-	model := NewChatModel(chatMode)
-	
+	model := NewChatModel(chatMode, "")
+
 	// Set some dimensions
 	model.width = 80
 	model.height = 24
-	
+
 	t.Run("input state", func(t *testing.T) {
 		model.state = ChatStateInput
 		view := model.View()
-		
+
 		assert.Contains(t, view, "💬 Chat Mode")
 		assert.Contains(t, view, "Enter: Send")
 		assert.Contains(t, view, "Ctrl+C/q: Quit")
 	})
-	
+
 	t.Run("loading state", func(t *testing.T) {
 		model.state = ChatStateLoading
 		model.loading = true
 		view := model.View()
-		
+
 		assert.Contains(t, view, "💬 Chat Mode")
 		assert.Contains(t, view, "🤖 Assistant is thinking")
 	})
-	
+
 	t.Run("error state", func(t *testing.T) {
 		model.state = ChatStateError
 		model.error = "Test error"
 		view := model.View()
-		
+
 		assert.Contains(t, view, "💬 Chat Mode - Error")
 		assert.Contains(t, view, "❌ Test error")
 		assert.Contains(t, view, "Press Esc to continue")
 	})
-	
+
 	t.Run("response state with messages", func(t *testing.T) {
 		model.state = ChatStateResponse
-		
+
 		// Add some messages
 		model.chatMode.conversation.Messages = []Message{
 			{Role: "user", Content: "Hello", Timestamp: time.Now()},
 			{Role: "assistant", Content: "Hi there!", Timestamp: time.Now()},
 		}
-		
+
 		view := model.View()
-		
+
 		assert.Contains(t, view, "💬 Chat Mode")
 		assert.Contains(t, view, "You (")
 		assert.Contains(t, view, "Assistant (")
@@ -364,40 +382,40 @@ func TestRenderChatHistory(t *testing.T) {
 	cfg := &config.Config{Provider: "mock", Model: "test-model", Markdown: true}
 	provider := &MockProvider{}
 	ui := ui.New()
-	
+
 	chatMode := NewChatMode(cfg, provider, ui)
-	model := NewChatModel(chatMode)
-	
+	model := NewChatModel(chatMode, "")
+
 	t.Run("empty conversation", func(t *testing.T) {
 		model.chatMode.conversation.Messages = []Message{}
 		history := model.renderChatHistory()
-		
+
 		assert.Contains(t, history, "No messages yet")
 	})
-	
+
 	t.Run("conversation with messages", func(t *testing.T) {
 		model.chatMode.conversation.Messages = []Message{
 			{Role: "user", Content: "Hello", Timestamp: time.Now()},
 			{Role: "assistant", Content: "**Hello!** How can I help?", Timestamp: time.Now()},
 		}
-		
+
 		history := model.renderChatHistory()
-		
+
 		assert.Contains(t, history, "You (")
 		assert.Contains(t, history, "Assistant (")
 		assert.Contains(t, history, "Hello")
 		// Should contain rendered markdown
 		assert.Contains(t, history, "How can I help")
 	})
-	
+
 	t.Run("system messages excluded", func(t *testing.T) {
 		model.chatMode.conversation.Messages = []Message{
 			{Role: "system", Content: "You are helpful", Timestamp: time.Now()},
 			{Role: "user", Content: "Hello", Timestamp: time.Now()},
 		}
-		
+
 		history := model.renderChatHistory()
-		
+
 		assert.NotContains(t, history, "You are helpful")
 		assert.Contains(t, history, "Hello")
 	})


### PR DESCRIPTION
## Summary
- default to streaming output and allow disabling via --no-stream
- launch chat TUI with optional initial prompt and show help when no args
- render streaming responses with markdown in inline mode and expand chat tests

## Testing
- `go test ./... -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68a21a396f7c83299500f21910b73f13

## Summary by Sourcery

Enable streaming output by default with a new --no-stream flag, enhance the chat TUI to accept an optional initial prompt and render streaming responses with Markdown in inline mode, simplify CLI argument handling across modes, and add environment variable expansion in configuration files.

New Features:
- Add --no-stream flag and default --stream to true in the CLI
- Support an optional initial prompt when launching chat mode and show help when no arguments are provided
- Render streaming inline responses as Markdown diffs in non-interactive mode

Enhancements:
- Refactor ChatModel to handle initial prompt in Init and queue the first request automatically
- Simplify run flow in main CLI to cleanly branch between inline, shell, and chat modes
- Implement file config loading to expand ${VAR} references from environment

Documentation:
- Update README to note support for ${VAR} expansion in configuration files

Tests:
- Expand chat mode tests to cover initial prompts, streaming chunks, view states, and error handling
- Enhance shell mode tests to support streaming chunks via MockProvider
- Add tests for environment variable substitution when loading config files